### PR TITLE
Add more details to README for Intro to Debugging Activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,33 @@
-# Errors and Debugging Roundtable Activity
+# Intro to Debugging Roundtable Activity
 
 ## Activity Workflow
 
-Work together with your group to identify and fix the bugs in this codebase.
-1. Take time to observe how Python reports the error in the stack trace
-2. Pay attention to
+Work together with your group in breakout rooms to identify and fix the bugs in this codebase.
+
+### Choose one teammate to execute the following steps:
+1. Fork and clone this repo
+2. Set up the project
+    * After cloning the project, change into the project directory: `cd errors-and-debugging`
+    * Create your virtual environment: `python -m venv venv`
+    * Activate your virtual environment: `source venv/bin/activate`
+
+### After the project has been set up, work together to identify and fix the bugs.
+1. From the root of the project directory, execute this terminal in this command: `python main.py` 
+2. Observe how Python reports the error in the stack trace. Make sure to work through the issues __together__ using VS Code’s LiveShare or Zoom screen sharing!
+3. Pay attention to
     * File names
     * Line numbers
     * Error type
-3. Before fixing each error:
+4. Before fixing each error:
     * State what the error is
     * Hypothesize the cause of the error
     * Propose a fix
   
-  *NOTE*: DO NOT edit any of the test_ functions
+  *NOTE*: DO NOT edit any of the `test_` functions
+
+### If you finish early, use this time to discuss your strategies for debugging together!
+* Potential discussion questions: 
+   * What have you tried in the past? 
+   * What worked well for you? 
+   * What strategies do you want more practice in? 
+   * How do you plan to incorporate them?


### PR DESCRIPTION
Many activity details are in the [roundtable slides](https://docs.google.com/presentation/d/10s0iC0xGdOtYiy4gaRKKEpx-LhtQJv1c2dVl5-I4rwU/edit?usp=sharing). This change adds these details to the activity README.